### PR TITLE
Fix WUE on Italian WoW

### DIFF
--- a/filter.lua
+++ b/filter.lua
@@ -128,12 +128,12 @@ function addon:GetBindString(msg)
 	if (msg) then
 		if (string_find(msg, ITEM_BIND_ON_EQUIP)) then
 			return addon.S_BOE
-		elseif (string_findm(msg, BOP_STRINGS)) then
-			return addon.S_BOP
 		elseif (string_findm(msg, WUE_STRINGS)) then
 			return addon.S_WUE
 		elseif (string_findm(msg, BOA_STRINGS)) then
 			return addon.S_BOA
+		elseif (string_findm(msg, BOP_STRINGS)) then
+			return addon.S_BOP
 		end
 	end
 end


### PR DESCRIPTION
Since, in Italian WoW, ITEM_SOULBOUND is "Vincolato" and ITEM_ACCOUNTBOUND_UNTIL_EQUIP is "Vincolato alla Brigata fino all'equipaggiamento" it's necessary to move BOP_STRINGS as the last check in order to avoid catching also WUE items.